### PR TITLE
small build script fix in MoveIt plugins package for RX160

### DIFF
--- a/staubli_rx160_moveit_plugins/CMakeLists.txt
+++ b/staubli_rx160_moveit_plugins/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(staubli_rx160_moveit_plugins)
 
-find_package(Eigen REQUIRED)
-include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
-
-find_package(LAPACK REQUIRED)
-
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   pluginlib
@@ -14,7 +9,8 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 include_directories(${catkin_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
+
+find_package(LAPACK REQUIRED)
 
 catkin_package(
   LIBRARIES


### PR DESCRIPTION
As per subject.

Packages generated using a recent version of `moveit_ikfast` already have these fixes.
