### PR TITLE
Add some more default colours to resources package

### DIFF
--- a/staubli_resources/urdf/common_colours.xacro
+++ b/staubli_resources/urdf/common_colours.xacro
@@ -1,20 +1,32 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- colours based on RAL values supplied by Staubli -->
+  <!-- all RAL colours converted using http://www.visual-graphics.de/en/customer-care/ral-colours -->
 
-  <!-- RAL 1018 -->
-  <xacro:property name="colour_staubli_ral_zinc_yellow"    value="0.973 0.953 0.208 1.0" />
+  <!-- default colours for robots -->
 
-  <!-- RAL 1028 -->
-  <xacro:property name="colour_staubli_ral_melon_yellow"   value="1.0 0.608 0.0 1.0" />
+  <!-- RAL 1028 - Melon yellow - scara (non-textured) and 6-axis (textured) robots -->
+  <xacro:property name="colour_staubli_ral_melon_yellow"   value="${255/255} ${155/255} ${  0/255} 1.0" />
 
-  <!-- RAL 7043 -->
-  <xacro:property name="colour_staubli_ral_traffic_grey_b" value="0.306 0.329 0.322 1.0" />
+  <!-- RAL 7035 - Light grey - scara robot ESD -->
+  <xacro:property name="colour_staubli_ral_light_grey"     value="${197/255} ${199/255} ${196/255} 1.0" />
 
-  <!-- RAL 9016 -->
-  <xacro:property name="colour_staubli_ral_traffic_white"  value="0.965 0.965 0.965 1.0" />
+  <!-- RAL 7045 - Telegrey 1 - scara robot base (textured) -->
+  <xacro:property name="colour_staubli_ral_telegrey_1"     value="${141/255} ${146/255} ${149/255} 1.0" />
+
+  <!-- RAL 7047 - Telegrey 4 - paint (smooth) -->
+  <xacro:property name="colour_staubli_ral_telegrey_4"     value="${200/255} ${200/255} ${199/255} 1.0" />
+
+  <!-- RAL 9007 - Grey aluminium - HE (smooth) -->
+  <xacro:property name="colour_staubli_ral_grey_aluminium" value="${135/255} ${133/255} ${129/255} 1.0" />
+
+  <!-- RAL 9016 - Traffic white - CR (smooth) -->
+  <xacro:property name="colour_staubli_ral_traffic_white"  value="${241/255} ${240/255} ${234/255} 1.0" />
+
 
   <!-- old colour definitions, for bw-compatibility. These are DEPRECATED. -->
   <xacro:property name="colour_staubli_yellow"             value="${colour_staubli_ral_melon_yellow}" />
   <xacro:property name="colour_staubli_white"              value="${colour_staubli_ral_traffic_white}" />
-
+  <xacro:property name="colour_staubli_ral_zinc_yellow"    value="0.973 0.953 0.208 1.0" />
+  <xacro:property name="colour_staubli_ral_traffic_grey_b" value="0.306 0.329 0.322 1.0" />
 </robot>

--- a/staubli_resources/urdf/common_materials.xacro
+++ b/staubli_resources/urdf/common_materials.xacro
@@ -2,21 +2,34 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find staubli_resources)/urdf/common_colours.xacro"/>
 
-  <xacro:macro name="material_staubli_ral_zinc_yellow">
-    <material name="">
-      <color rgba="${colour_staubli_ral_zinc_yellow}"/>
-    </material>
-  </xacro:macro>
-
+  <!-- default colors for robots -->
   <xacro:macro name="material_staubli_ral_melon_yellow">
     <material name="">
       <color rgba="${colour_staubli_ral_melon_yellow}"/>
     </material>
   </xacro:macro>
 
-  <xacro:macro name="material_staubli_ral_traffic_grey_b">
+  <xacro:macro name="material_staubli_ral_light_grey">
     <material name="">
-      <color rgba="${colour_staubli_ral_traffic_grey_b}"/>
+      <color rgba="${colour_staubli_ral_light_grey}"/>
+    </material>
+  </xacro:macro>
+
+  <xacro:macro name="material_staubli_ral_telegrey_1">
+    <material name="">
+      <color rgba="${colour_staubli_ral_telegrey_1}"/>
+    </material>
+  </xacro:macro>
+
+  <xacro:macro name="material_staubli_ral_telegrey_4">
+    <material name="">
+      <color rgba="${colour_staubli_ral_telegrey_4}"/>
+    </material>
+  </xacro:macro>
+
+  <xacro:macro name="material_staubli_ral_grey_aluminium">
+    <material name="">
+      <color rgba="${colour_staubli_ral_grey_aluminium}"/>
     </material>
   </xacro:macro>
 
@@ -35,6 +48,16 @@
   <xacro:macro name="material_staubli_white">
     <material name="">
       <color rgba="${colour_staubli_white}"/>
+    </material>
+  </xacro:macro>
+  <xacro:macro name="material_staubli_ral_zinc_yellow">
+    <material name="">
+      <color rgba="${colour_staubli_ral_zinc_yellow}"/>
+    </material>
+  </xacro:macro>
+  <xacro:macro name="material_staubli_ral_traffic_grey_b">
+    <material name="">
+      <color rgba="${colour_staubli_ral_traffic_grey_b}"/>
     </material>
   </xacro:macro>
 


### PR DESCRIPTION
New colours based on information I received from Staubli directly.

Comments in `common_colours.xacro` provide hints as to for which types/models/variants specific colours should be used.
