### PR TITLE
fix compilation on melodic by using typedefs

### DIFF
--- a/staubli_rx160_moveit_plugins/package.xml
+++ b/staubli_rx160_moveit_plugins/package.xml
@@ -31,6 +31,7 @@
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>tf_conversions</depend>
+  <depend>liblapack-dev</depend>
 
 
   <export>

--- a/staubli_rx160_moveit_plugins/package.xml
+++ b/staubli_rx160_moveit_plugins/package.xml
@@ -27,11 +27,11 @@
   <url type="repository">https://github.com/ros-industrial/staubli</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>liblapack-dev</depend>
   <depend>moveit_core</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>tf_conversions</depend>
-  <depend>liblapack-dev</depend>
 
 
   <export>

--- a/staubli_rx160_moveit_plugins/rx160_kinematics/src/staubli_rx160_manipulator_ikfast_moveit_plugin.cpp
+++ b/staubli_rx160_moveit_plugins/rx160_kinematics/src/staubli_rx160_manipulator_ikfast_moveit_plugin.cpp
@@ -299,12 +299,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(tip_frame_));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(tip_frame_);
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)


### PR DESCRIPTION
this fixes compilation on melodic by replacing boost::shared_ptr with the transparent typedefs from MoveIt

see also https://github.com/ros-industrial/fanuc/pull/262

Note that this plugin should probably be replaced with an OPW config ...