### PR TITLE
add melodic and melodic-testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ env:
     - USE_DEB=true
       ROS_DISTRO="indigo"
       ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true
+      ROS_DISTRO="melodic"
+      ROS_REPOSITORY_PATH="http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true
+      ROS_DISTRO="melodic"
+      ROS_REPOSITORY_PATH=http://packages.ros.org/ros-testing/ubuntu
 
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config


### PR DESCRIPTION
this adds melodic as a test target (due to api changes) and also changes indigo/ros-shadow-fixed to melodic/ros-testing. However I have to admit I don't know the full rationale behind listing testing/shadow-fixed here as changes there/in dependencies won't trigger a rebuild? 