### PR TITLE
resources: remove deprecated colour and material defs.

### DIFF
--- a/staubli_resources/urdf/common_colours.xacro
+++ b/staubli_resources/urdf/common_colours.xacro
@@ -22,9 +22,4 @@
 
   <!-- RAL 9016 - Traffic white - CR (smooth) -->
   <xacro:property name="colour_staubli_ral_traffic_white"  value="${241/255} ${240/255} ${234/255} 1.0" />
-
-
-  <!-- old colour definitions, for bw-compatibility. These are DEPRECATED. -->
-  <xacro:property name="colour_staubli_yellow"             value="${colour_staubli_ral_melon_yellow}" />
-  <xacro:property name="colour_staubli_white"              value="${colour_staubli_ral_traffic_white}" />
 </robot>

--- a/staubli_resources/urdf/common_materials.xacro
+++ b/staubli_resources/urdf/common_materials.xacro
@@ -38,16 +38,4 @@
       <color rgba="${colour_staubli_ral_traffic_white}"/>
     </material>
   </xacro:macro>
-
-  <!-- old material definitions, for bw-compatibility. These are DEPRECATED. -->
-  <xacro:macro name="material_staubli_yellow">
-    <material name="">
-      <color rgba="${colour_staubli_yellow}"/>
-    </material>
-  </xacro:macro>
-  <xacro:macro name="material_staubli_white">
-    <material name="">
-      <color rgba="${colour_staubli_white}"/>
-    </material>
-  </xacro:macro>
 </robot>


### PR DESCRIPTION
As per subject.

These have been deprecated for at least 4 years and are not used by any 'official' `.xacro`.
