### PR TITLE
Increase minimum CMake version to allow builds on Focal Fossa (Noetic)

### DIFF
--- a/staubli/CMakeLists.txt
+++ b/staubli/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(staubli)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/staubli_resources/CMakeLists.txt
+++ b/staubli_resources/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(staubli_resources)
 

--- a/staubli_rx160_moveit_config/CMakeLists.txt
+++ b/staubli_rx160_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(staubli_rx160_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/staubli_rx160_moveit_plugins/CMakeLists.txt
+++ b/staubli_rx160_moveit_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(staubli_rx160_moveit_plugins)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/staubli_rx160_support/CMakeLists.txt
+++ b/staubli_rx160_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(staubli_rx160_support)
 


### PR DESCRIPTION
Related to https://github.com/ros-industrial/ros_industrial_issues/issues/67