### PR TITLE
do not enforce C++11

### DIFF
--- a/staubli_rx160_moveit_plugins/CMakeLists.txt
+++ b/staubli_rx160_moveit_plugins/CMakeLists.txt
@@ -8,11 +8,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
 )
 
-# enable C++11 if needed for MoveIt on Kinetic
-if ("${moveit_core_VERSION}" VERSION_GREATER "0.9.0")
-  add_definitions(-std=c++11)
-endif()
-
 include_directories(${catkin_INCLUDE_DIRS})
 
 find_package(LAPACK REQUIRED)


### PR DESCRIPTION
melodic defaults to C++11 and ros-o requires 17